### PR TITLE
Music docker test

### DIFF
--- a/lib/frameworks/capybara.rb
+++ b/lib/frameworks/capybara.rb
@@ -239,9 +239,8 @@ class CapybaraSetup
     Capybara.run_server = false
     options = {
       js_errors: false,
-      js: true,
       timeout:   120,
-      window_size: [1900, 5000],
+      window_size: [1200, 1000],
       phantomjs_options: phantom_opts,
       default_wait_time: 30
     }

--- a/lib/frameworks/capybara.rb
+++ b/lib/frameworks/capybara.rb
@@ -239,8 +239,9 @@ class CapybaraSetup
     Capybara.run_server = false
     options = {
       js_errors: false,
+      js: true,
       timeout:   120,
-      window_size: [1200, 1000],
+      window_size: [1900, 5000],
       phantomjs_options: phantom_opts,
       default_wait_time: 30
     }

--- a/lib/frameworks/extensions/patches.rb
+++ b/lib/frameworks/extensions/patches.rb
@@ -13,7 +13,7 @@ module Capybara
       old_visit url
       return if [:mechanize, :poltergeist].include?(Capybara.current_driver)
       surpress_cookies_prompt
-      #reload_if_survey_appears
+      reload_if_survey_appears
       close_music_banner
     end
 

--- a/lib/frameworks/wait.rb
+++ b/lib/frameworks/wait.rb
@@ -55,7 +55,7 @@ module FrameworksCapybara
             end
           end
         end
-      rescue TimeoutError
+      rescue Timeout::Error
         puts '********************************************************************'
         puts "Timed out after waiting for #{timeout} seconds."
         puts exception_message


### PR DESCRIPTION
Hello Both @GarethWalker @SwatiTabib ,

I have made 2 small changes, Please have a look.
1. TimeoutError is deprecated with ruby 2.3.0, which is replcaed by Timeout::Error
2. As we are running on local servers (docker) we need to reintroduce reload on survey appears.

Thanks,
Ankit
